### PR TITLE
Add missing end-quotes to strings and correctly handle special characters in strings

### DIFF
--- a/Sources/SwiftJSONSanitizer/SwiftJSONSanitizer.swift
+++ b/Sources/SwiftJSONSanitizer/SwiftJSONSanitizer.swift
@@ -183,6 +183,11 @@ public struct SwiftJSONSanitizer {
       
       switch char {
         case ExpectedType.objectStart.char():
+		  if expectedTypes.contains(.valueStringEnd) {
+			  formatted.append(char)
+			  break
+		  }
+
           if !openedStructures.isEmpty, indentLevel > 0, !expectedTypes.contains(.arrayStart) {
             removeTrailingComma(&formatted)
             
@@ -198,7 +203,12 @@ public struct SwiftJSONSanitizer {
           expectedTypes = [.keyStart, .objectEnd]
           
         case ExpectedType.arrayStart.char():
-          if !openedStructures.isEmpty, indentLevel > 0, !expectedTypes.contains(.arrayStart) {
+		  if expectedTypes.contains(.valueStringEnd) {
+			  formatted.append(char)
+			  break
+		  }
+		  
+		  if !openedStructures.isEmpty, indentLevel > 0, !expectedTypes.contains(.arrayStart) {
             removeTrailingComma(&formatted)
             
             // Close any open structures if necessary
@@ -223,6 +233,11 @@ public struct SwiftJSONSanitizer {
             .arrayEnd
           ]
         case ExpectedType.objectEnd.char():
+		  if expectedTypes.contains(.valueStringEnd) {
+			  formatted.append(char)
+			  break
+		  }
+
           if expectedTypes.contains(.objectEnd) {
             removeTrailingComma(&formatted)
 
@@ -240,6 +255,11 @@ public struct SwiftJSONSanitizer {
           }
           
         case ExpectedType.arrayEnd.char():
+		  if expectedTypes.contains(.valueStringEnd) {
+			  formatted.append(char)
+			  break
+		  }
+
           if expectedTypes.contains(.arrayEnd) {
             removeTrailingComma(&formatted)
 
@@ -293,6 +313,11 @@ public struct SwiftJSONSanitizer {
             expectedTypes = [.keyEnd]
           }
         case ExpectedType.colon.char():
+		  if expectedTypes.contains(.valueStringEnd) {
+			  formatted.append(char)
+			  break
+		  }
+
           if expectedTypes.contains(.colon) {
             formatted.append(ExpectedType.colon.char())
             formatted.append(options.valueSeparationChar)
@@ -309,7 +334,12 @@ public struct SwiftJSONSanitizer {
             ]
           }
         case ExpectedType.comma.char():
-          if expectedTypes.contains(.comma), !expectedTypes.contains(.valueStringEnd) {
+		  if expectedTypes.contains(.valueStringEnd) {
+			  formatted.append(char)
+			  break
+		  }
+
+          if expectedTypes.contains(.comma) {
             if valueBeingIgnored {
               valueBeingIgnored.toggle()
             }

--- a/Tests/SwiftJSONSanitizerTests/SwiftJSONSanitizerTests.swift
+++ b/Tests/SwiftJSONSanitizerTests/SwiftJSONSanitizerTests.swift
@@ -251,6 +251,32 @@ final class SwiftJSONSanitizerTests: XCTestCase {
     XCTAssertEqual(SwiftJSONSanitizer.sanitize(input), expected)
   }
   
+	func testMissingEndQuote() {
+		let input = "{\"key\": \"string with no end quote"
+		let expected = """
+			{
+			  "key": "string with no end quote"
+			}
+			"""
+
+		XCTAssertEqual(SwiftJSONSanitizer.sanitize(input), expected)
+	}
+	
+	func testMissingEndQuoteInArray() {
+		let input = "{\"key\": [\"string with an end quote\", \"string with no end quote"
+		let expected = """
+			{
+			  "key": [
+			    "string with an end quote",
+			    "string with no end quote"
+			  ]
+			}
+			"""
+		let result = SwiftJSONSanitizer.sanitize(input)
+		print(result)
+		XCTAssertEqual(result, expected)
+	}
+	
   func testEscapedQuotesInString() {
     let input = "{\"key\": \"string with \\\"quotes\\\"\"}"
     let expected = """

--- a/Tests/SwiftJSONSanitizerTests/SwiftJSONSanitizerTests.swift
+++ b/Tests/SwiftJSONSanitizerTests/SwiftJSONSanitizerTests.swift
@@ -8,7 +8,6 @@ import Foundation
 @testable import SwiftJSONSanitizer
 
 final class SwiftJSONSanitizerTests: XCTestCase {
-  
   func testValidJSON() {
     let input = "{\"key\": [11, 12, 13]}"
     let expected = """
@@ -251,32 +250,57 @@ final class SwiftJSONSanitizerTests: XCTestCase {
     XCTAssertEqual(SwiftJSONSanitizer.sanitize(input), expected)
   }
   
-	func testMissingEndQuote() {
-		let input = "{\"key\": \"string with no end quote"
-		let expected = """
-			{
-			  "key": "string with no end quote"
-			}
-			"""
+  func testMissingEndQuote() {
+    let input = "{\"key\": \"string with no end quote"
+    let expected = """
+    {
+      "key": "string with no end quote"
+    }
+    """
+    
+    XCTAssertEqual(SwiftJSONSanitizer.sanitize(input), expected)
+  }
+  
+  func testMissingEndQuoteInArray() {
+    let input = "{\"key\": [\"string with an end quote\", \"string with no end quote"
+    let expected = """
+    {
+      "key": [
+        "string with an end quote",
+        "string with no end quote"
+      ]
+    }
+    """
+    let result = SwiftJSONSanitizer.sanitize(input)
+    XCTAssertEqual(result, expected)
+  }
+  
+  func testCommaInString() {
+    let input = """
+    {"description":"This, and that
+    """
+    
+    let expected = """
+   {
+     "description": "This, and that"
+   }
+   """
+    XCTAssertEqual(SwiftJSONSanitizer.sanitize(input), expected)
+  }
+  
+  func testBracketsAndBracesInString() {
+    let input = """
+    {"description":"This, {and} [that
+    """
+    
+    let expected = """
+    {
+      "description": "This, {and} [that"
+    }
+    """
+    XCTAssertEqual(SwiftJSONSanitizer.sanitize(input), expected)
+  }
 
-		XCTAssertEqual(SwiftJSONSanitizer.sanitize(input), expected)
-	}
-	
-	func testMissingEndQuoteInArray() {
-		let input = "{\"key\": [\"string with an end quote\", \"string with no end quote"
-		let expected = """
-			{
-			  "key": [
-			    "string with an end quote",
-			    "string with no end quote"
-			  ]
-			}
-			"""
-		let result = SwiftJSONSanitizer.sanitize(input)
-		print(result)
-		XCTAssertEqual(result, expected)
-	}
-	
   func testEscapedQuotesInString() {
     let input = "{\"key\": \"string with \\\"quotes\\\"\"}"
     let expected = """


### PR DESCRIPTION
I have a use-case for this that involves streaming structured content token-by-token back from an LLM. This library turned out to be a great find! In order to stream the text as it's written, I need to be able to insert close-quotes as well as braces and brackets. 

I also noticed that the library has trouble with special characters appearing in strings — for example:

```
{
   "text": "This is a [Markdown Link](https://...)"
}
```

The library incorrectly interprets the `[` character as an array start. I believe I fixed that as well. 

Let me know if you have any questions or want to see some more test cases!